### PR TITLE
Use celery.shared_task rather than celery.task. Closes #7

### DIFF
--- a/pushy/tasks/__init__.py
+++ b/pushy/tasks/__init__.py
@@ -6,7 +6,9 @@ from ..dispatchers import get_dispatcher, Dispatcher
 from pushy.models import get_filtered_devices_queryset, Device
 
 
-@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(
+    queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default')
+)
 def check_pending_push_notifications():
     pending_notifications = PushNotification.objects.filter(
         sent=PushNotification.PUSH_NOT_SENT)
@@ -19,7 +21,9 @@ def check_pending_push_notifications():
         pending_notification.save()
 
 
-@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(
+    queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default')
+)
 def create_push_notification_groups(notification_id):
     try:
         notification = PushNotification.objects.get(pk=notification_id)
@@ -36,7 +40,9 @@ def create_push_notification_groups(notification_id):
             for offset in range(0, count, limit)).delay()
 
 
-@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(
+    queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default')
+)
 def send_push_notification_group(notification_id, offset=0, limit=1000):
     try:
         notification = PushNotification.objects.get(pk=notification_id)
@@ -53,7 +59,9 @@ def send_push_notification_group(notification_id, offset=0, limit=1000):
     return True
 
 
-@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(
+    queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default')
+)
 def send_single_push_notification(device, payload):
     # The task can be called in two ways:
     # 1) from send_push_notification_group directly with a device instance

--- a/pushy/tasks/__init__.py
+++ b/pushy/tasks/__init__.py
@@ -1,12 +1,12 @@
 from django.conf import settings
-from celery import task, group
+import celery
 
 from ..models import PushNotification
 from ..dispatchers import get_dispatcher, Dispatcher
 from pushy.models import get_filtered_devices_queryset, Device
 
 
-@task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
 def check_pending_push_notifications():
     pending_notifications = PushNotification.objects.filter(
         sent=PushNotification.PUSH_NOT_SENT)
@@ -19,7 +19,7 @@ def check_pending_push_notifications():
         pending_notification.save()
 
 
-@task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
 def create_push_notification_groups(notification_id):
     try:
         notification = PushNotification.objects.get(pk=notification_id)
@@ -31,12 +31,12 @@ def create_push_notification_groups(notification_id):
     if devices.count() > 0:
         count = devices.count()
         limit = getattr(settings, 'PUSHY_DEVICE_KEY_LIMIT', 1000)
-        group(send_push_notification_group.s(
+        celery.group(send_push_notification_group.s(
             notification_id, offset, limit)
             for offset in range(0, count, limit)).delay()
 
 
-@task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
 def send_push_notification_group(notification_id, offset=0, limit=1000):
     try:
         notification = PushNotification.objects.get(pk=notification_id)
@@ -53,7 +53,7 @@ def send_push_notification_group(notification_id, offset=0, limit=1000):
     return True
 
 
-@task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
+@celery.shared_task(queue=getattr(settings, 'PUSHY_QUEUE_DEFAULT_NAME', 'default'))
 def send_single_push_notification(device, payload):
     # The task can be called in two ways:
     # 1) from send_push_notification_group directly with a device instance


### PR DESCRIPTION
The shared_task decorator loosely couples to the projects configure Celery
application by returning a proxy that always uses the same task instance for
the `current_app`.