### PR TITLE
Added setting to allow sending JSON payloads with GCM. Closes #12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ Configurations::
     # Android
     PUSHY_GCM_API_KEY = 'YOUR_API_KEY_HERE'
 
-    # Send JSON payload to GCM server (default is to send as plaintext)
-    PUSHY_GCM_JSON_PAYLOAD = False
+    # Send JSON or plaintext payload to GCM server (default is JSON)
+    PUSHY_GCM_JSON_PAYLOAD = True
 
     # iOS
     PUSHY_APNS_SANDBOX = True or False

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ Configurations::
     # Android
     PUSHY_GCM_API_KEY = 'YOUR_API_KEY_HERE'
 
+    # Send JSON payload to GCM server (default is to send as plaintext)
+    PUSHY_GCM_JSON_PAYLOAD = False
+
     # iOS
     PUSHY_APNS_SANDBOX = True or False
     PUSHY_APNS_KEY_FILE = 'PATH_TO_KEY_FILE'

--- a/pushy/dispatchers.py
+++ b/pushy/dispatchers.py
@@ -165,7 +165,7 @@ class GCMDispatcher(Dispatcher):
     def send(self, device_key, data):
         gcm_api_key = getattr(settings, 'PUSHY_GCM_API_KEY', None)
 
-        gcm_json_payload = getattr(settings, 'PUSHY_GCM_JSON_PAYLOAD', False)
+        gcm_json_payload = getattr(settings, 'PUSHY_GCM_JSON_PAYLOAD', True)
 
         if not gcm_api_key:
             raise PushGCMApiKeyException()

--- a/pushy/dispatchers.py
+++ b/pushy/dispatchers.py
@@ -164,6 +164,9 @@ class APNSDispatcher(Dispatcher):
 class GCMDispatcher(Dispatcher):
     def send(self, device_key, data):
         gcm_api_key = getattr(settings, 'PUSHY_GCM_API_KEY', None)
+
+        gcm_json_payload = getattr(settings, 'PUSHY_GCM_JSON_PAYLOAD', False)
+
         if not gcm_api_key:
             raise PushGCMApiKeyException()
 
@@ -171,8 +174,17 @@ class GCMDispatcher(Dispatcher):
 
         # Plaintext request
         try:
-            canonical_id = gcm.plaintext_request(registration_id=device_key,
-                                                 data=data)
+            if gcm_json_payload:
+                request_method = gcm.json_request
+
+                # json_request takes a list of registration IDs
+                registration_id = [device_key]
+            else:
+                request_method = gcm.plaintext_request
+                registration_id = device_key
+
+            canonical_id = request_method(registration_id, data=data)
+
             if canonical_id:
                 return self.PUSH_RESULT_SENT, canonical_id
             else:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -27,5 +27,7 @@ ROOT_URLCONF = 'core.urls'
 CELERY_ALWAYS_EAGER = True
 PUSHY_GCM_API_KEY = 'blah-blah'
 
+PUSHY_GCM_JSON_PAYLOAD = False
+
 PUSHY_APNS_CERTIFICATE_FILE = 'aps_development.pem'
 PUSHY_APNS_KEY_FILE = 'private_key.pem'

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -42,12 +42,11 @@ class DispatchersTestCase(TestCase):
         with mock.patch('django.conf.settings.PUSHY_GCM_API_KEY', new=None):
             self.assertRaises(PushGCMApiKeyException, android.send, device_key, data)
 
-        with mock.patch('django.conf.settings.PUSHY_GCM_JSON_PAYLOAD', new=True), \
-                mock.patch('gcm.GCM.json_request') as json_request_mock:
+        with mock.patch('django.conf.settings.PUSHY_GCM_JSON_PAYLOAD', new=True):
+            with mock.patch('gcm.GCM.json_request') as json_request_mock:
+                android.send(device_key, data)
 
-            android.send(device_key, data)
-
-            self.assertTrue(json_request_mock.called)
+                self.assertTrue(json_request_mock.called)
 
         # Check result when canonical value is returned
         gcm = mock.Mock()

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -42,6 +42,13 @@ class DispatchersTestCase(TestCase):
         with mock.patch('django.conf.settings.PUSHY_GCM_API_KEY', new=None):
             self.assertRaises(PushGCMApiKeyException, android.send, device_key, data)
 
+        with mock.patch('django.conf.settings.PUSHY_GCM_JSON_PAYLOAD', new=True), \
+                mock.patch('gcm.GCM.json_request') as json_request_mock:
+
+            android.send(device_key, data)
+
+            self.assertTrue(json_request_mock.called)
+
         # Check result when canonical value is returned
         gcm = mock.Mock()
         gcm.return_value = 123123


### PR DESCRIPTION
This change adds a setting to allow the user to choose between sending plaintext or JSON payloads to GCM.