### PR TITLE
Update models.py for compatibility with Django 2.0

### DIFF
--- a/pushy/models.py
+++ b/pushy/models.py
@@ -71,7 +71,7 @@ class Device(models.Model):
 
     key = models.CharField(max_length=255)
     type = models.SmallIntegerField(choices=DEVICE_TYPE_CHOICES)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, on_delete='CASCADE')
 
     class Meta:
         unique_together = ('key', 'type')


### PR DESCRIPTION
`on_delete` will be mandatory in Django 2.0:

```
File "…/site-packages/pushy/models.py", line 74, in Device
    user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
TypeError: __init__() missing 1 required positional argument: 'on_delete'
```

- [Features removed in 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0)